### PR TITLE
Adding SES sending via SMTP

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,11 +7,14 @@ mod "puppetlabs/mysql"
 mod "saz/memcached"
 mod "hunner/hiera"
 mod "branan/s3file"
-mod "evenup/postfix"
 mod "evenup/varnish"
 
 mod "apache",
   :git => "https://github.com/puppetlabs/puppetlabs-apache.git"
+
+mod "postfix",
+  :git => "https://github.com/huit/evenup-postfix.git",
+  :ref => 'mediawiki-poc'
 
 mod "mediawiki",
   :git => "git://github.com/huit/puppet-mediawiki.git",

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -8,6 +8,10 @@ node default {
   $default_database_user     = 'mediawiki'
   $default_database_password = 'mediawiki'
   $default_application_port  = '8080'
+  $default_smtp_endpoint     = 'localhost'
+  $default_smtp_port         = '25'
+  # $default_smtp_domain       = $::domain
+  $default_smtp_domain       = 'devel.huit.harvard.edu'
 
   # parameters passed from nepho
   $nepho_instance_role     = hiera('NEPHO_INSTANCE_ROLE')
@@ -21,27 +25,30 @@ node default {
   $nepho_s3_bucket         = hiera('NEPHO_S3_BUCKET',false)
   $nepho_s3_access_key     = hiera('NEPHO_S3_BUCKET_ACCESS','no_s3_bucket_access_provided')
   $nepho_s3_secret_key     = hiera('NEPHO_S3_BUCKET_KEY','no_s3_bucket_secret_provided')
-  $nepho_mail_relay_host   = hiera('NEPHO_MAIL_RELAY_HOST','')
+  $nepho_ses_smtp          = str2bool(hiera('NEPHO_SES_SMTP','false'))
+  $nepho_ses_smtp_endpoint = hiera('NEPHO_SES_SMTP_ENDPOINT',$default_smtp_endpoint)
+  $nepho_ses_smtp_port     = hiera('NEPHO_SES_SMTP_PORT',$default_smtp_port)
+  $nepho_ses_smtp_username = hiera('NEPHO_SES_SMTP_USER',false)
+  $nepho_ses_smtp_password = hiera('NEPHO_SES_SMTP_PASSWORD',false)
+  $nepho_ses_smtp_domain   = hiera('NEPHO_SES_SMTP_DOMAIN',$default_smtp_domain)
 
   $probe_interval     = "30s"
   $probe_timeout      = "10s"
   $probe_window       = "5"
   $purge_ips          = [  ]
 
-  exec { 'preinstall-postfix':
-    command   => '/usr/bin/yum -y install postfix',
-    creates   => '/etc/postfix',
-    before    => Class['postfix'],
-    logoutput => 'on_failure',
-  }
-
-  if $nepho_mail_relay_host {
+  if $nepho_ses_smtp {
     class { 'postfix':
-      relay_host => $nepho_mail_relay_host,
+      smtp_relay     => false,
+      tls            => true,
+      tls_bundle     => '/etc/ssl/certs/ca-bundle.crt',
+      tls_package    => 'ca-certificates',
+      mydomain       => $nepho_ses_smtp_domain,
+      relay_host     => $nepho_ses_smtp_endpoint,
+      relay_port     => $nepho_ses_smtp_port,
+      relay_username => $nepho_ses_smtp_username,
+      relay_password => $nepho_ses_smtp_password,
     }
-  }
-  else {
-    class { 'postfix': }
   }
 
   if $nepho_instance_role {


### PR DESCRIPTION
Add parameters like the following to your YAML config:

```
SESSMTP: 'true'
SESEndpoint: '<the SES SMTP endpoint for your region>'
SESUsername: '<your SMTP IAM username'
SESPassword: '<your SMTP IAM password>'
```

Then your instance will be able to send (not receive) email with a local
MTA via SES.
